### PR TITLE
Added Change to Typer call for help on no argument

### DIFF
--- a/chasten/main.py
+++ b/chasten/main.py
@@ -27,7 +27,7 @@ from chasten import (
 )
 
 # create a Typer object to support the command-line interface
-cli = typer.Typer()
+cli = typer.Typer(no_args_is_help=True)
 
 # create a small bullet for display in the output
 small_bullet_unicode = constants.markers.Small_Bullet_Unicode


### PR DESCRIPTION
made `chasten --help` command run when `chasten` is called.

I did this by changing the `typer` object creation to allow for `no_args_is_help=True`