### PR TITLE
Creation of version command

### DIFF
--- a/chasten/checks.py
+++ b/chasten/checks.py
@@ -1,8 +1,13 @@
 """Extract and analyze details about specific checks."""
 
-from typing import Dict, List, Tuple, Union
+from typing import Dict
+from typing import List
+from typing import Tuple
+from typing import Union
 
-from chasten import constants, enumerations, util
+from chasten import constants
+from chasten import enumerations
+from chasten import util
 
 
 def extract_min_max(

--- a/chasten/database.py
+++ b/chasten/database.py
@@ -6,7 +6,10 @@ from pathlib import Path
 
 from sqlite_utils import Database
 
-from chasten import constants, enumerations, filesystem, output
+from chasten import constants
+from chasten import enumerations
+from chasten import filesystem
+from chasten import output
 
 CHASTEN_SQL_SELECT_QUERY = """
 SELECT

--- a/chasten/filesystem.py
+++ b/chasten/filesystem.py
@@ -5,12 +5,21 @@ import shutil
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, NoReturn, Optional, Tuple, Union
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import NoReturn
+from typing import Optional
+from typing import Tuple
+from typing import Union
 
 import flatterer  # type: ignore
 from rich.tree import Tree
 
-from chasten import configuration, constants, database, results
+from chasten import configuration
+from chasten import constants
+from chasten import database
+from chasten import results
 
 CONFIGURATION_FILE_DEFAULT_CONTENTS = """
 # chasten configuration

--- a/chasten/main.py
+++ b/chasten/main.py
@@ -2,7 +2,11 @@
 
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Tuple
+from typing import Union
 
 import typer
 import yaml
@@ -10,21 +14,19 @@ from pyastgrep import search as pyastgrepsearch  # type: ignore
 from trogon import Trogon  # type: ignore
 from typer.main import get_group
 
-from chasten import (
-    checks,
-    configuration,
-    constants,
-    database,
-    debug,
-    enumerations,
-    filesystem,
-    output,
-    process,
-    results,
-    server,
-    util,
-    validate,
-)
+from chasten import checks
+from chasten import configuration
+from chasten import constants
+from chasten import database
+from chasten import debug
+from chasten import enumerations
+from chasten import filesystem
+from chasten import output
+from chasten import process
+from chasten import results
+from chasten import server
+from chasten import util
+from chasten import validate
 
 # create a Typer object to support the command-line interface
 cli = typer.Typer()
@@ -909,6 +911,7 @@ def log() -> None:
     # before running any sub-command
     # of the chasten tool
     server.start_syslog_server()
+
 
 @cli.command()
 def version():

--- a/chasten/main.py
+++ b/chasten/main.py
@@ -912,11 +912,11 @@ def log() -> None:
 
 @cli.command()
 def version():
-    """Display the version of Chasten."""
+    """🖥️  Display the version of chasten."""
     # Get Chasten version from util file
     version_string = util.get_chasten_version()
     # output chasten version
-    typer.echo(f"{version_string}")
+    typer.echo(f"chasten {version_string}")
 
 
 # ---

--- a/chasten/output.py
+++ b/chasten/output.py
@@ -3,14 +3,20 @@
 import logging
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any
+from typing import Dict
+from typing import List
 
 from pyastgrep import search as pyastgrepsearch  # type: ignore
 from rich.console import Console
 from rich.panel import Panel
 from rich.syntax import Syntax
 
-from chasten import checks, configuration, constants, debug, results
+from chasten import checks
+from chasten import configuration
+from chasten import constants
+from chasten import debug
+from chasten import results
 
 # declare a default logger
 logger: logging.Logger = logging.getLogger()

--- a/chasten/process.py
+++ b/chasten/process.py
@@ -1,12 +1,17 @@
 """Analyze the abstract syntax tree, its XML-based representation, and/or the search results."""
 
 import json
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Tuple
+from typing import Union
 
 from pyastgrep import search as pyastgrepsearch  # type: ignore
 from thefuzz import fuzz  # type: ignore
 
-from chasten import constants, enumerations
+from chasten import constants
+from chasten import enumerations
 
 
 def include_or_exclude_checks(

--- a/chasten/results.py
+++ b/chasten/results.py
@@ -3,7 +3,8 @@
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import List, Union
+from typing import List
+from typing import Union
 
 from pyastgrep import search as pyastgrepsearch  # type: ignore
 from pydantic import BaseModel

--- a/chasten/server.py
+++ b/chasten/server.py
@@ -4,7 +4,8 @@ import logging
 import logging.handlers
 import socketserver
 
-from chasten import constants, output
+from chasten import constants
+from chasten import output
 
 LOG_FILE = constants.server.Log_File
 HOST = constants.server.Localhost

--- a/chasten/util.py
+++ b/chasten/util.py
@@ -1,6 +1,7 @@
 """Utilities for use within chasten."""
 
 import importlib.metadata
+
 import pkg_resources
 
 from chasten import constants
@@ -44,12 +45,14 @@ def get_chasten_version() -> str:
         try:
             # if importlib.metadata fails, try using pkg_resources
             # The 'distribution' variable holds information about the 'chasten' package
-            distribution= pkg_resources.get_distribution(constants.chasten.Application_Name)
+            distribution = pkg_resources.get_distribution(
+                constants.chasten.Application_Name
+            )
             # Retrieve version information from distribution
-            version_string_of_foo= distribution.version
+            version_string_of_foo = distribution.version
         except pkg_resources.DistributionNotFound:
             # If both methods fail, return a default version
-            version_string_of_foo = default_chasten_semver.version
+            version_string_of_foo = default_chasten_semver
     return version_string_of_foo
 
 

--- a/chasten/validate.py
+++ b/chasten/validate.py
@@ -1,6 +1,9 @@
 """Validate various aspects of configurations and command-line arguments."""
 
-from typing import Any, Dict, List, Tuple
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Tuple
 
 import jsonschema
 from jsonschema.exceptions import ValidationError

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -2,14 +2,14 @@
 
 import hypothesis.strategies as st
 import pytest
-from hypothesis import HealthCheck, given, settings
+from hypothesis import HealthCheck
+from hypothesis import given
+from hypothesis import settings
 from hypothesis_jsonschema import from_schema
 
-from chasten.checks import (
-    check_match_count,
-    extract_min_max,
-    is_in_closed_interval,
-)
+from chasten.checks import check_match_count
+from chasten.checks import extract_min_max
+from chasten.checks import is_in_closed_interval
 
 JSON_SCHEMA_COUNT = {
     "type": "object",

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -3,7 +3,8 @@
 import logging
 
 import pytest
-from hypothesis import given, strategies
+from hypothesis import given
+from hypothesis import strategies
 
 from chasten import configuration
 

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -3,7 +3,8 @@
 from dataclasses import FrozenInstanceError
 
 import pytest
-from hypothesis import given, strategies
+from hypothesis import given
+from hypothesis import strategies
 
 from chasten import constants
 

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -2,7 +2,8 @@
 
 import pytest
 
-from chasten.debug import DebugDestination, DebugLevel
+from chasten.debug import DebugDestination
+from chasten.debug import DebugLevel
 
 
 def test_debug_level_values():

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -4,10 +4,12 @@ import pathlib
 from unittest.mock import patch
 
 import pytest
-from hypothesis import given, strategies
+from hypothesis import given
+from hypothesis import strategies
 from rich.tree import Tree
 
-from chasten import constants, filesystem
+from chasten import constants
+from chasten import filesystem
 
 
 def test_valid_directory() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,10 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from hypothesis import HealthCheck, given, settings, strategies
+from hypothesis import HealthCheck
+from hypothesis import given
+from hypothesis import settings
+from hypothesis import strategies
 from typer.testing import CliRunner
 
 from chasten import main

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,8 @@
 """Pytest test suite for the util module."""
 
 import pytest
-from hypothesis import given, strategies
+from hypothesis import given
+from hypothesis import strategies
 
 from chasten import util
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,10 +1,12 @@
 """Pytest test suite for the validate module."""
 
 import pytest
-from hypothesis import given, strategies
+from hypothesis import given
+from hypothesis import strategies
 from hypothesis_jsonschema import from_schema
 
-from chasten.validate import JSON_SCHEMA_CONFIG, validate_configuration
+from chasten.validate import JSON_SCHEMA_CONFIG
+from chasten.validate import validate_configuration
 
 
 def test_validate_config_valid_realistic():


### PR DESCRIPTION
This is @Jaclynpqc's work, with very minor touchups from me.

Creates the command `chasten version` in order to give off the version that is given to `chasten` from PyPi. At the time of writing, this command gives off the output `chasten 1.1.0`.