### PR TITLE
fix: removing covbadge to free the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,7 @@ jobs:
             echo "### Total coverage: ${TOTAL}%" >> $GITHUB_STEP_SUMMARY
             CURRENT_GITHUB_STEP_SUMMARY="\`\`\`\n$(cat coverage.txt)\n\`\`\`"
             echo "$CURRENT_GITHUB_STEP_SUMMARY" >> $GITHUB_STEP_SUMMARY
+<<<<<<< Updated upstream
         # Create the Coverage Badge
         - name: Make Badge
           uses: schneegans/dynamic-badges-action@v1.6.0
@@ -108,3 +109,5 @@ jobs:
             minColorRange: 50
             maxColorRange: 90
             valColorRange: ${{ env.total }}
+=======
+>>>>>>> Stashed changes


### PR DESCRIPTION
This PR removes the covbadge build step in order prevent our build from being persistently halted by its faultiness. If merged, we would need to document the fact that this is a temporary change, meaning we would need to reconsider how to fix this issue down the line. For now, considering how 'green' the code base is, we need to prioritize other features.

I will create another PR that reverts this one so that we will have a pending re-implementation of this PR. I will put a note that it needs to be a `hold` status.

This closes #86, closes #84, and closes #82