### PR TITLE
Restrict and better document the calculation and reporting of coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,13 +104,3 @@ jobs:
             echo "### Total coverage: ${TOTAL}%" >> $GITHUB_STEP_SUMMARY
             CURRENT_GITHUB_STEP_SUMMARY="\`\`\`\n$(cat coverage.txt)\n\`\`\`"
             echo "$CURRENT_GITHUB_STEP_SUMMARY" >> $GITHUB_STEP_SUMMARY
-        # Run and display the test coverage
-        # If the current operating system is not Linux, then only run test
-        # coverage monitoring and display it inside of the GitHub Actions
-        # panel. This allows for test coverage to be calculated for each
-        # operating system. However, coverage is only reported for Linux
-        # through the badge and through the GitHub job summary.
-        - name: Run and Report Test Coverage - MacOS and Windows Only
-          if: always() && matrix.os != 'ubuntu-latest'
-          run: |
-            poetry run task test-coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,12 +105,14 @@ jobs:
             CURRENT_GITHUB_STEP_SUMMARY="\`\`\`\n$(cat coverage.txt)\n\`\`\`"
             echo "$CURRENT_GITHUB_STEP_SUMMARY" >> $GITHUB_STEP_SUMMARY
         # Run and display the test coverage
-        # If the current operating system is not Linux, then only run test
+        # If the current operating system is MacOS, then only run test
         # coverage monitoring and display it inside of the GitHub Actions
         # panel. This allows for test coverage to be calculated for each
         # operating system. However, coverage is only reported for Linux
-        # through the badge and through the GitHub job summary.
-        - name: Run and Report Test Coverage - MacOS and Windows Only
+        # through the badge and through the GitHub job summary. Do not
+        # run any test coverage monitoring in Windows because it seems
+        # to be much slower and cause hypothesis-based tests to fail.
+        - name: Run and Report Test Coverage - MacOS Only
           if: always() && matrix.os == 'macOS'
           run: |
             poetry run task test-coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,3 +104,13 @@ jobs:
             echo "### Total coverage: ${TOTAL}%" >> $GITHUB_STEP_SUMMARY
             CURRENT_GITHUB_STEP_SUMMARY="\`\`\`\n$(cat coverage.txt)\n\`\`\`"
             echo "$CURRENT_GITHUB_STEP_SUMMARY" >> $GITHUB_STEP_SUMMARY
+        # Run and display the test coverage
+        # If the current operating system is not Linux, then only run test
+        # coverage monitoring and display it inside of the GitHub Actions
+        # panel. This allows for test coverage to be calculated for each
+        # operating system. However, coverage is only reported for Linux
+        # through the badge and through the GitHub job summary.
+        - name: Run and Report Test Coverage - MacOS and Windows Only
+          if: always() && matrix.os == 'macOS'
+          run: |
+            poetry run task test-coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,13 +90,13 @@ jobs:
             poetry run task test
         # Run and collect the test coverage
         # Important: only run and collect test coverage monitoring on Linux
-        - name: Run and Collect Test Coverage
+        - name: Run and Collect Test Coverage - Linux Only
           if: always() && matrix.os == 'ubuntu-latest'
           run: |
             poetry run task test-coverage-silent > coverage.txt
         # Display the Coverage Report
         # Important: only report the monitored test coverage on Linux
-        - name: Display Collected Test Coverage
+        - name: Display Collected Test Coverage - Linux Only
           if: always() && matrix.os == 'ubuntu-latest'
           run: |
             export TOTAL=$(python -c "import json;print(json.load(open('coverage.json'))['totals']['percent_covered_display'])")
@@ -110,7 +110,7 @@ jobs:
         # panel. This allows for test coverage to be calculated for each
         # operating system. However, coverage is only reported for Linux
         # through the badge and through the GitHub job summary.
-        - name: Run and Report Test Coverage
+        - name: Run and Report Test Coverage - MacOS and Windows Only
           if: always() && matrix.os != 'ubuntu-latest'
           run: |
             poetry run task test-coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           if: always()
           run: |
             poetry run task lint
-          # Run the program
+        # Run the program
         - name: Run program
           if: always()
           run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,13 +88,15 @@ jobs:
           if: always()
           run: |
             poetry run task test
-        # Run the test coverage monitoring
-        - name: Run Test Coverage
-          if: always()
+        # Run and collect the test coverage
+        # Important: only run and collect test coverage monitoring on Linux
+        - name: Run and Collect Test Coverage
+          if: always() && matrix.os == 'ubuntu-latest'
           run: |
             poetry run task test-coverage-silent > coverage.txt
         # Display the Coverage Report
-        - name: Display Coverage
+        # Important: only report the monitored test coverage on Linux
+        - name: Display Collected Test Coverage
           if: always() && matrix.os == 'ubuntu-latest'
           run: |
             export TOTAL=$(python -c "import json;print(json.load(open('coverage.json'))['totals']['percent_covered_display'])")
@@ -102,3 +104,13 @@ jobs:
             echo "### Total coverage: ${TOTAL}%" >> $GITHUB_STEP_SUMMARY
             CURRENT_GITHUB_STEP_SUMMARY="\`\`\`\n$(cat coverage.txt)\n\`\`\`"
             echo "$CURRENT_GITHUB_STEP_SUMMARY" >> $GITHUB_STEP_SUMMARY
+        # Run and display the test coverage
+        # If the current operating system is not Linux, then only run test
+        # coverage monitoring and display it inside of the GitHub Actions
+        # panel. This allows for test coverage to be calculated for each
+        # operating system. However, coverage is only reported for Linux
+        # through the badge and through the GitHub job summary.
+        - name: Run and Report Test Coverage
+          if: always() && matrix.os != 'ubuntu-latest'
+          run: |
+            poetry run task test-coverage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ on:
     branches: [ master ]
 
 # Create one single job
-# This job performs all necessary checks
+# This job performs all of the necessary checks
 jobs:
   build:
     # Use the latest version of Ubuntu, MacOS, and Windows

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,13 @@ jobs:
   build:
     # Use the latest version of Ubuntu, MacOS, and Windows
     # Use the latest and most stable version of Python
+    # Important: test coverage monitoring and reporting
+    # through a badge and the GitHub Actions job summary
+    # only takes place with the Linux operating system.
+    # Important: the MacOS and Windows operating systems
+    # have test coverage calculation take place but they
+    # do not report the test coverage beyond its display
+    # inside of the GitHub Actions panel for that job.
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,7 +1,7 @@
 """Pytest test suite for the validate module."""
 
 import pytest
-from hypothesis import given, strategies
+from hypothesis import HealthCheck, given, settings, strategies
 from hypothesis_jsonschema import from_schema
 
 from chasten.validate import JSON_SCHEMA_CONFIG, validate_configuration
@@ -44,6 +44,7 @@ def test_validate_empty_config(config):
 
 
 @given(from_schema(JSON_SCHEMA_CONFIG))
+@settings(suppress_health_check=[HealthCheck.too_slow])
 @pytest.mark.fuzz
 def test_integers(config):
     """Use Hypothesis and the JSON schema plugin to confirm validation works for all possible valid instances."""


### PR DESCRIPTION
This PR modifies the way in which test coverage is calculated and reported.

Here are some details:

- Only calculate and display code coverage in the GitHub job summary and through the badge when the build runs on Linux
- Otherwise, only calculate test coverage and show it locally in the build tab. This means that MacOS will have a calculation of test coverage but it will not influence the GitHub Actions job summary or the coverage badge.
- Make more of the Hypothesis tests tolerant to slow testing processes.
- Only run the test coverage monitoring process on MacOS right now since slow test coverage monitoring seems to happen more frequently on the Windows operating system.
