### PR TITLE
Add documentation of verbose output on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,20 @@ CSV files that correspond to each of the tables inside of the database.
 You can learn more about the `integrate` sub-command by typing `chasten
 integrate --help`.
 
+## 💠 Verbose Output
+
+You can see the verbose output when running various functions, you can include `--verbose` to return more information about the program execution. Here is an example with `chasten analyze lazytracker`:
+
+```shell
+chasten analyze lazytracker \
+        --config <path to the chasten-configuration/ directory> \
+        --search-path <path to the lazytracker/ directory> \
+        --save-directory <path to the subject-data/lazytracker/ directory> \
+        --save
+        --verbose
+ ```
+
+
 ## 🌄 Results
 
 If you want to create an interactive analysis dashboard that uses 📦

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ integrate --help`.
 
 ## 💠 Verbose Output
 
-You can see the verbose output when running various functions, you can include `--verbose` to return more information about the program execution. Here is an example with `chasten analyze lazytracker`:
+By adding the `--verbose` flag to the `chasten analyze lazytracker` command, you will receive more detailed information about the program execution. This can be useful for troubleshooting and understanding how the tool is working behind the scenes Here is an example with `chasten analyze lazytracker`:
 
 ```shell
 chasten analyze lazytracker \
@@ -250,6 +250,7 @@ chasten analyze lazytracker \
         --save
         --verbose
  ```
+
 
 
 ## 🌄 Results

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ integrate --help`.
 
 ## 💠 Verbose Output
 
-By adding the `--verbose` flag to the `chasten analyze lazytracker` command, you will receive more detailed information about the program execution. This can be useful for troubleshooting and understanding how the tool is working behind the scenes Here is an example with `chasten analyze lazytracker`:
+Adding the `--verbose` flag to the `chasten` command can be useful for troubleshooting and understanding how the tool is working behind the scenes Here is an example with `chasten analyze lazytracker`:
 
 ```shell
 chasten analyze lazytracker \

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ integrate --help`.
 
 ## 💠 Verbose Output
 
-Adding the `--verbose` flag to the `chasten` command can be useful for troubleshooting and understanding how the tool is working behind the scenes Here is an example with `chasten analyze lazytracker`:
+When utilizing the `chasten` command, appending this `--verbose` flag can significantly enhance your troubleshooting experience and provide a detailed understanding of the tool's functionality. Here is an example with `chasten analyze lazytracker`:
 
 ```shell
 chasten analyze lazytracker \
@@ -251,7 +251,7 @@ chasten analyze lazytracker \
         --verbose
  ```
 
-You will notice that the output return `✨ Matching source code:` comparing the source code with checked patterns and finding detailed match of different check, for example: `🎉 Found a total of 1 matches for 'single-nested-if-anywhere-in-module' in`.
+Upon executing this command, you can expect the output to contain informative messages such as `✨ Matching source code:` indicating that the tool is actively comparing the source code against the specified patterns. Additionally, you will receive detailed match results, providing insights into the identified checks.
 
 ## 🌄 Results
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ chasten analyze lazytracker \
         --verbose
  ```
 
-
+You will notice that the output return `✨ Matching source code:` comparing the source code with checked patterns and finding detailed match of different check, for example: `🎉 Found a total of 1 matches for 'single-nested-if-anywhere-in-module' in`.
 
 ## 🌄 Results
 

--- a/chasten/main.py
+++ b/chasten/main.py
@@ -441,7 +441,7 @@ def analyze(  # noqa: PLR0913, PLR0915
     save: bool = typer.Option(False, help="Enable saving of output file(s)."),
 ) -> None:
     """💫 Analyze the AST of Python source code."""
-    # add logger
+        # add logger
     output.setup(debug_level, debug_destination)
     output.logger.debug(f"Display verbose output? {verbose}")
     output.logger.debug(f"Debug level? {debug_level.value}")

--- a/chasten/main.py
+++ b/chasten/main.py
@@ -441,6 +441,11 @@ def analyze(  # noqa: PLR0913, PLR0915
     save: bool = typer.Option(False, help="Enable saving of output file(s)."),
 ) -> None:
     """💫 Analyze the AST of Python source code."""
+    # add logger
+    output.setup(debug_level, debug_destination)
+    output.logger.debug(f"Display verbose output? {verbose}")
+    output.logger.debug(f"Debug level? {debug_level.value}")
+    output.logger.debug(f"Debug destination? {debug_destination.value}")
     # output the preamble, including extra parameters specific to this function
     output_preamble(
         verbose,

--- a/chasten/main.py
+++ b/chasten/main.py
@@ -441,11 +441,6 @@ def analyze(  # noqa: PLR0913, PLR0915
     save: bool = typer.Option(False, help="Enable saving of output file(s)."),
 ) -> None:
     """💫 Analyze the AST of Python source code."""
-        # add logger
-    output.setup(debug_level, debug_destination)
-    output.logger.debug(f"Display verbose output? {verbose}")
-    output.logger.debug(f"Debug level? {debug_level.value}")
-    output.logger.debug(f"Debug destination? {debug_destination.value}")
     # output the preamble, including extra parameters specific to this function
     output_preamble(
         verbose,

--- a/chasten/main.py
+++ b/chasten/main.py
@@ -481,7 +481,6 @@ def analyze(  # noqa: PLR0913, PLR0915
     output.console.print()
     # validate the configuration
     (validated, checks_dict) = validate_configuration_files(config, verbose)
-    output.logger.debug(f"Validate the configuration: {config}")
     # some aspect of the configuration was not
     # valid, so exit early and signal an error
     if not validated:

--- a/chasten/main.py
+++ b/chasten/main.py
@@ -547,7 +547,6 @@ def analyze(  # noqa: PLR0913, PLR0915
         match_generator = pyastgrepsearch.search_python_files(
             paths=valid_directories, expression=current_xpath_pattern, xpath2=True
         )
-        output.logger.debug(f"Match Generator {match_generator}")
         # materialize a list from the generator of (potential) matches;
         # note that this list will also contain an object that will
         # indicate that the analysis completed for each located file

--- a/chasten/main.py
+++ b/chasten/main.py
@@ -456,6 +456,7 @@ def analyze(  # noqa: PLR0913, PLR0915
     )
     # extract the current version of the program
     chasten_version = util.get_chasten_version()
+    output.logger.debug(f"Current version of chasten: {chasten_version}")
     # create the include and exclude criteria
     include = results.CheckCriterion(
         attribute=str(checks.fix_check_criterion(check_include[0])),
@@ -485,6 +486,7 @@ def analyze(  # noqa: PLR0913, PLR0915
     output.console.print()
     # validate the configuration
     (validated, checks_dict) = validate_configuration_files(config, verbose)
+    output.logger.debug(f"Validate the configuration: {config}")
     # some aspect of the configuration was not
     # valid, so exit early and signal an error
     if not validated:
@@ -542,6 +544,7 @@ def analyze(  # noqa: PLR0913, PLR0915
         # extract details about the check to display in the header
         # of the syntax box for this specific check
         check_id = current_check[constants.checks.Check_Id]  # type: ignore
+        output.logger.debug(f"check id: {check_id}")
         check_name = current_check[constants.checks.Check_Name]  # type: ignore
         check_description = checks.extract_description(current_check)
         # search for the XML contents of an AST that match the provided
@@ -550,6 +553,7 @@ def analyze(  # noqa: PLR0913, PLR0915
         match_generator = pyastgrepsearch.search_python_files(
             paths=valid_directories, expression=current_xpath_pattern, xpath2=True
         )
+        output.logger.debug(f"Match Generator {match_generator}")
         # materialize a list from the generator of (potential) matches;
         # note that this list will also contain an object that will
         # indicate that the analysis completed for each located file


### PR DESCRIPTION
This pull request adds information and illustration of verbose output to the README file, as right now there is no information about it. 
This pull request links to [Issue #26](https://github.com/AstuteSource/chasten/issues/26)