### PR TITLE
fix: datasette fstring incorrectly written

### DIFF
--- a/chasten/database.py
+++ b/chasten/database.py
@@ -224,7 +224,7 @@ def start_datasette_server(  # noqa: PLR0912, PLR0913
         # datasette-publish-fly plugin) and thus need to exit and not proceed
         if not found_publish_platform_executable:
             output.console.print(
-                ":person_shrugging: Was not able to find '{datasette_platform}'"
+                f":person_shrugging: Was not able to find '{datasette_platform}'"
             )
             return None
         # was able to find the fly or vercel executable that will support the


### PR DESCRIPTION
This fixes a formatting error in a formatted string in `database.py`. A variable supposed to be printed in this would not have had its value read because the formatted string was missing the `f` character that prefixes a python string to make it a formatted one.

5. This will not affect coverage.

6. Tested on `NixOS 22.11.2301.cff83d5032a`