### PR TITLE
Added projectname in sql for a new required argument

### DIFF
--- a/datasette/metadata.json
+++ b/datasette/metadata.json
@@ -35,12 +35,13 @@
           THEN substr(context, 1, instr(context, '[') - 1)
           ELSE
           context
+          JSON.stringify(obj, projectname)
           END AS stripped_text
           FROM
           context;"
         },
       }
     }
-
+    
   }
 }


### PR DESCRIPTION
In the 'sql' section of the .json file for chasten which calls the datasette function, I have added a line which produces a string which calls the project name (projectname) to be printed. This is so there is a new hard-coded name for an appilcation project which is printed, as described in the issue tracker.