### PR TITLE
gitignore analysis.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -369,3 +369,6 @@ coverage.json
 
 # bash command history
 .bash_history
+
+# viewable markdown analysis
+analysis.md


### PR DESCRIPTION
With the new feature of browsable markdown reports, I'm adding `analysis.md` to `.gitignore` so we do not have to worry about committing it to version history.