### PR TITLE
fix: Datasette-publish can now find the executable

### DIFF
--- a/chasten/database.py
+++ b/chasten/database.py
@@ -207,7 +207,7 @@ def start_datasette_server(  # noqa: PLR0912, PLR0913
         (
             found_publish_platform_executable,
             publish_platform_executable,
-        ) = filesystem.can_find_executable(datasette_platform)
+        ) = filesystem.can_find_executable(util.executable_name(datasette_platform))
         # was not able to find the fly or vercel executable (the person using this
         # program has to install separately, following the instructions for the
         # datasette-publish-fly plugin) and thus need to exit and not proceed

--- a/chasten/main.py
+++ b/chasten/main.py
@@ -986,6 +986,7 @@ def datasette_publish(  # noqa: PLR0913
         datasette_metadata=metadata,
         datasette_platform=datasette_platform.value,
         publish=True,
+        OpSystem=util.get_OS(),
     )
 
 


### PR DESCRIPTION
This is a solution to #117 it uses the executable_name function added to fix #51 it doesn't cause any issues with coverage as there is already a test case for the function and I have confirmed that all of the linters and test cases pass